### PR TITLE
Fix hybrid-scanner event-loop saturation: tolerate partial scanner failure, backoff on registration-change restarts

### DIFF
--- a/custom_components/renpho_fitness_scale_ble/coordinator.py
+++ b/custom_components/renpho_fitness_scale_ble/coordinator.py
@@ -1344,8 +1344,11 @@ class ScaleDataUpdateCoordinator:
         flapping/bootlooping proxy could otherwise keep pre-empting the
         backoff timer faster than the backoff is meant to allow (no leak,
         but repeated real I/O load) - `REGISTRATION_PREEMPT_DEBOUNCE_SECONDS`
-        is a hard floor on that specific path. A successful restart resets
-        the backoff.
+        is a hard floor on that specific path. It only applies while a
+        backoff retry is pending (i.e. restarts are currently failing); it
+        does not throttle events while restarts are succeeding, since
+        pre-emption - and therefore this risk - can't occur on that path.
+        A successful restart resets the backoff.
         """
         if self._restart_retry_unsub is not None:
             # A backoff retry is already scheduled, but this is a real
@@ -1355,6 +1358,11 @@ class ScaleDataUpdateCoordinator:
             # and try now - but only if enough time has passed since the
             # last attempt; otherwise leave the scheduled backoff retry
             # alone so repeated events can't drive back-to-back restarts.
+            # `_last_restart_attempt_monotonic` is always set by the time
+            # `_restart_retry_unsub` is non-None (both happen in the same
+            # call, `_last_restart_attempt_monotonic` first), so the None
+            # case below is unreachable today - kept as a defensive guard
+            # in case that invariant ever changes.
             since_last_attempt = (
                 None
                 if self._last_restart_attempt_monotonic is None

--- a/custom_components/renpho_fitness_scale_ble/coordinator.py
+++ b/custom_components/renpho_fitness_scale_ble/coordinator.py
@@ -881,6 +881,14 @@ class ScaleDataUpdateCoordinator:
         # change event firing during the initial start could double-start
         # the client.
         self._start_lock = asyncio.Lock()
+        # Set once by `async_stop`, under `_start_lock`. Lets a
+        # `_async_registration_changed` call that was already scheduled
+        # before the stop (e.g. a registration event that fired just
+        # before unload) notice, once it's its turn at the lock, that the
+        # coordinator is gone and bail out instead of building a new scale
+        # client after shutdown. Never reset - each config-entry setup
+        # creates a fresh coordinator instance.
+        self._stopped = False
         # Backoff state for scanner-change restarts (see
         # `_async_registration_changed`). Counts consecutive `_async_start`
         # failures and holds the cancel handle of the (single, coalesced)
@@ -1357,6 +1365,16 @@ class ScaleDataUpdateCoordinator:
         A successful restart resets the backoff.
         """
         async with self._start_lock:
+            if self._stopped:
+                # A registration event scheduled this call before
+                # `async_stop` ran (e.g. right before unload) but only
+                # got the lock afterwards - `async_stop` already tore
+                # down `self._scale`; don't build a new one.
+                _LOGGER.debug(
+                    "Registration-change event arrived after the "
+                    "coordinator was stopped; ignoring"
+                )
+                return
             since_last_attempt = (
                 None
                 if self._last_restart_attempt_monotonic is None
@@ -1464,7 +1482,18 @@ class ScaleDataUpdateCoordinator:
         return logger
 
     async def async_stop(self) -> None:
-        """Stop the scale client and clean up callbacks."""
+        """Stop the scale client and clean up callbacks.
+
+        Takes `_start_lock` around the actual client teardown so this
+        can't run concurrently with an in-flight `_async_start()` (called
+        from here or from `_async_registration_changed`) - without it, a
+        restart racing with unload could leave a freshly-built scale
+        client running after this returns, or double-stop/`AttributeError`
+        on the client being torn down mid-rebuild. `_stopped` is set
+        first, before touching `self._scale`, so a registration event that
+        was already scheduled before this call notices once it's its turn
+        at the lock and bails out instead of building a new client.
+        """
         if self._unsub_core_config_update is not None:
             self._unsub_core_config_update()
             self._unsub_core_config_update = None
@@ -1476,16 +1505,18 @@ class ScaleDataUpdateCoordinator:
         if self._restart_retry_unsub is not None:
             self._restart_retry_unsub()
             self._restart_retry_unsub = None
-        if self._scale is not None:
-            try:
-                await self._scale.async_stop()
-            except Exception:
-                # Benign on teardown/restart: BlueZ can report
-                # `org.bluez.Error.Failed: No discovery started` when the scan
-                # was already stopped. Don't let it surface as an unhandled
-                # task-exception traceback.
-                _LOGGER.exception("Error stopping scale client")
-            self._scale = None
+        async with self._start_lock:
+            self._stopped = True
+            if self._scale is not None:
+                try:
+                    await self._scale.async_stop()
+                except Exception:
+                    # Benign on teardown/restart: BlueZ can report
+                    # `org.bluez.Error.Failed: No discovery started` when the scan
+                    # was already stopped. Don't let it surface as an unhandled
+                    # task-exception traceback.
+                    _LOGGER.exception("Error stopping scale client")
+                self._scale = None
 
     # ------------------------------------------------------------------
     # Listener registries

--- a/custom_components/renpho_fitness_scale_ble/coordinator.py
+++ b/custom_components/renpho_fitness_scale_ble/coordinator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import platform
+import time
 from collections.abc import Callable
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
@@ -127,6 +128,18 @@ PENDING_MEASUREMENT_MAX_AGE = timedelta(hours=24)
 # run often enough to saturate the HA event loop for hours.
 RESTART_BACKOFF_BASE_SECONDS = 30
 RESTART_BACKOFF_MAX_SECONDS = 1800  # 30 minutes
+
+
+# Hard floor between scale-client restart attempts triggered by a
+# registration event pre-empting a pending backoff retry (see
+# `_async_registration_changed`). HA's scanner-registration callback isn't
+# itself rate-limited, so without this floor a flapping/bootlooping BT
+# proxy could keep pre-empting the backoff timer on every flap and drive
+# back-to-back `_async_start()` cycles - no leak (that's fixed), but
+# repeated real I/O load faster than the backoff is meant to allow. Applies
+# only to the pre-emption path; it does not touch the backoff delay itself
+# or the no-backoff-pending (restarts currently succeeding) path.
+REGISTRATION_PREEMPT_DEBOUNCE_SECONDS = 5
 
 
 # How long to ignore advertisements from the scale after a successful
@@ -874,6 +887,10 @@ class ScaleDataUpdateCoordinator:
         # scheduled retry.
         self._restart_failures = 0
         self._restart_retry_unsub: Callable[[], None] | None = None
+        # Monotonic timestamp of the last `_async_start` attempt made from
+        # `_async_registration_changed`, used to enforce
+        # `REGISTRATION_PREEMPT_DEBOUNCE_SECONDS` on the pre-emption path.
+        self._last_restart_attempt_monotonic: float | None = None
         self._display_unit: WeightUnit = WeightUnit.KG
         self._config_entry_id: str | None = None
 
@@ -1322,16 +1339,40 @@ class ScaleDataUpdateCoordinator:
         30min cap): a *real* registration event (a scanner actually being
         added/removed) instead cancels any pending backoff retry and
         restarts immediately, since the event itself could be exactly
-        what fixes the failure (e.g. an ESPHome proxy reconnecting). This
-        can't reintroduce a hot loop because registration events are
-        rate-limited by real adapter/proxy-reconnect cadence, unlike a
-        self-scheduled retry. A successful restart resets the backoff.
+        what fixes the failure (e.g. an ESPHome proxy reconnecting).
+        Registration events aren't rate-limited by HA itself, though, so a
+        flapping/bootlooping proxy could otherwise keep pre-empting the
+        backoff timer faster than the backoff is meant to allow (no leak,
+        but repeated real I/O load) - `REGISTRATION_PREEMPT_DEBOUNCE_SECONDS`
+        is a hard floor on that specific path. A successful restart resets
+        the backoff.
         """
         if self._restart_retry_unsub is not None:
             # A backoff retry is already scheduled, but this is a real
             # registration-change event, not the retry timer firing (the
             # timer's own callback clears `_restart_retry_unsub` before
-            # calling back in here) - cancel the pending retry and try now.
+            # calling back in here). Normally we'd cancel the pending retry
+            # and try now - but only if enough time has passed since the
+            # last attempt; otherwise leave the scheduled backoff retry
+            # alone so repeated events can't drive back-to-back restarts.
+            since_last_attempt = (
+                None
+                if self._last_restart_attempt_monotonic is None
+                else time.monotonic() - self._last_restart_attempt_monotonic
+            )
+            if (
+                since_last_attempt is not None
+                and since_last_attempt < REGISTRATION_PREEMPT_DEBOUNCE_SECONDS
+            ):
+                _LOGGER.debug(
+                    "Registration-change event arrived %.1fs after the "
+                    "last restart attempt (< %ds debounce floor); leaving "
+                    "the scheduled backoff retry in place instead of "
+                    "pre-empting it",
+                    since_last_attempt,
+                    REGISTRATION_PREEMPT_DEBOUNCE_SECONDS,
+                )
+                return
             _LOGGER.debug(
                 "Scale client restart already scheduled (backoff after %d "
                 "failure(s)); registration-change event pre-empting it for "
@@ -1342,6 +1383,7 @@ class ScaleDataUpdateCoordinator:
             self._restart_retry_unsub = None
         _LOGGER.debug("BT scanner registration changed; restarting scale client")
         try:
+            self._last_restart_attempt_monotonic = time.monotonic()
             async with self._start_lock:
                 await self._async_start()
         except Exception:

--- a/custom_components/renpho_fitness_scale_ble/coordinator.py
+++ b/custom_components/renpho_fitness_scale_ble/coordinator.py
@@ -737,10 +737,16 @@ class BleakScannerHybrid(BaseBleakScanner):
         )
 
     async def stop(self) -> None:
-        """Stop scanning for devices."""
-        if not self._scanning:
-            return
+        """Stop scanning for devices.
 
+        Stops every scanner in ``self._scanners`` unconditionally, not
+        gated behind ``self._scanning``. A hybrid that never finished
+        starting (e.g. ``self._scanning`` still ``False`` for any reason
+        other than the already-handled partial-failure path in
+        ``start()``) must still have its children stopped — otherwise a
+        live, subscribed scanner could again be stranded, as happened
+        before ``start()`` was fixed to clean up after itself.
+        """
         for scanner in self._scanners:
             try:
                 await scanner.stop()
@@ -1310,19 +1316,30 @@ class ScaleDataUpdateCoordinator:
         proxy reconnect triggers another full failing rebuild — and via the
         leak in ``BleakScannerHybrid.start()`` fixed above, each one adds
         more permanently-subscribed scanners on top, saturating the HA
-        event loop for hours. Now, while restarts are failing, further
-        registration events are coalesced into a single scheduled retry
-        whose delay grows exponentially (30s -> 30min cap). A successful
-        restart resets the backoff.
+        event loop for hours. The backoff now governs only the
+        *self-scheduled* retries (the timer fired by
+        ``_schedule_restart_retry``, delay growing exponentially, 30s ->
+        30min cap): a *real* registration event (a scanner actually being
+        added/removed) instead cancels any pending backoff retry and
+        restarts immediately, since the event itself could be exactly
+        what fixes the failure (e.g. an ESPHome proxy reconnecting). This
+        can't reintroduce a hot loop because registration events are
+        rate-limited by real adapter/proxy-reconnect cadence, unlike a
+        self-scheduled retry. A successful restart resets the backoff.
         """
         if self._restart_retry_unsub is not None:
-            # A backoff retry is already scheduled; coalesce this event.
+            # A backoff retry is already scheduled, but this is a real
+            # registration-change event, not the retry timer firing (the
+            # timer's own callback clears `_restart_retry_unsub` before
+            # calling back in here) - cancel the pending retry and try now.
             _LOGGER.debug(
                 "Scale client restart already scheduled (backoff after %d "
-                "failure(s)); coalescing registration-change event",
+                "failure(s)); registration-change event pre-empting it for "
+                "an immediate retry",
                 self._restart_failures,
             )
-            return
+            self._restart_retry_unsub()
+            self._restart_retry_unsub = None
         _LOGGER.debug("BT scanner registration changed; restarting scale client")
         try:
             async with self._start_lock:

--- a/custom_components/renpho_fitness_scale_ble/coordinator.py
+++ b/custom_components/renpho_fitness_scale_ble/coordinator.py
@@ -131,14 +131,14 @@ RESTART_BACKOFF_MAX_SECONDS = 1800  # 30 minutes
 
 
 # Hard floor between scale-client restart attempts triggered by a
-# registration event pre-empting a pending backoff retry (see
-# `_async_registration_changed`). HA's scanner-registration callback isn't
-# itself rate-limited, so without this floor a flapping/bootlooping BT
-# proxy could keep pre-empting the backoff timer on every flap and drive
-# back-to-back `_async_start()` cycles - no leak (that's fixed), but
-# repeated real I/O load faster than the backoff is meant to allow. Applies
-# only to the pre-emption path; it does not touch the backoff delay itself
-# or the no-backoff-pending (restarts currently succeeding) path.
+# registration event (see `_async_registration_changed`). HA's
+# scanner-registration callback isn't itself rate-limited, so without this
+# floor a flapping/bootlooping BT proxy could drive back-to-back
+# `_async_start()` cycles - no leak (that's fixed), but repeated real I/O
+# load faster than the backoff is meant to allow. Applies unconditionally
+# to every restart attempt made from a registration event, regardless of
+# whether a backoff retry happens to be pending - it does not touch the
+# backoff delay itself.
 REGISTRATION_PREEMPT_DEBOUNCE_SECONDS = 5
 
 

--- a/custom_components/renpho_fitness_scale_ble/coordinator.py
+++ b/custom_components/renpho_fitness_scale_ble/coordinator.py
@@ -1500,13 +1500,20 @@ class ScaleDataUpdateCoordinator:
         if self._scanner_change_cb_unregister is not None:
             self._scanner_change_cb_unregister()
             self._scanner_change_cb_unregister = None
-        # Cancel any pending backoff retry so a stopped/unloaded coordinator
-        # can't restart itself later.
-        if self._restart_retry_unsub is not None:
-            self._restart_retry_unsub()
-            self._restart_retry_unsub = None
         async with self._start_lock:
             self._stopped = True
+            # Cancel any pending backoff retry so a stopped/unloaded
+            # coordinator can't restart itself later. Done under the lock,
+            # right after setting `_stopped`: an in-flight restart holds
+            # the lock for its whole attempt, including scheduling a new
+            # backoff retry on failure, so by the time we get the lock
+            # ourselves any such retry has already been scheduled and is
+            # visible here to cancel - it can't be scheduled afterwards
+            # and slip past this check, since `_stopped` makes any later
+            # restart attempt a no-op before it would reach that point.
+            if self._restart_retry_unsub is not None:
+                self._restart_retry_unsub()
+                self._restart_retry_unsub = None
             if self._scale is not None:
                 try:
                     await self._scale.async_stop()

--- a/custom_components/renpho_fitness_scale_ble/coordinator.py
+++ b/custom_components/renpho_fitness_scale_ble/coordinator.py
@@ -718,9 +718,10 @@ class BleakScannerHybrid(BaseBleakScanner):
                 )
                 # The scanner's own start() failed, but it may still have
                 # partially initialized (e.g. subscribed to advertisements)
-                # before raising. Stop it explicitly rather than relying on
-                # BleakScannerHybrid.stop(), which no-ops until
-                # self._scanning is True.
+                # before raising. Stop it explicitly here rather than via
+                # self.stop() — self._scanners still holds every scanner in
+                # this loop, so self.stop() would also stop scanners that
+                # already started successfully in this same pass.
                 try:
                     await scanner.stop()
                 except Exception:  # noqa: BLE001

--- a/custom_components/renpho_fitness_scale_ble/coordinator.py
+++ b/custom_components/renpho_fitness_scale_ble/coordinator.py
@@ -37,6 +37,7 @@ from homeassistant.components import persistent_notification
 from homeassistant.const import UnitOfMass
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
+from homeassistant.helpers.event import async_call_later
 from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import MassConverter
 from multi_user_scale_core import (
@@ -117,6 +118,15 @@ _LOGGER = logging.getLogger(__name__)
 # every new pending insert and once on coordinator restore — so stale
 # entries can't survive a long HA-offline window followed by a restart.
 PENDING_MEASUREMENT_MAX_AGE = timedelta(hours=24)
+
+
+# Backoff for scale-client restarts triggered by BT-scanner-registration
+# changes (see `_async_registration_changed`). Without this, a scanner that
+# keeps failing to (re)start gets a full pipeline rebuild attempt on every
+# single registration event (e.g. each ESPHome proxy reconnect), which can
+# run often enough to saturate the HA event loop for hours.
+RESTART_BACKOFF_BASE_SECONDS = 30
+RESTART_BACKOFF_MAX_SECONDS = 1800  # 30 minutes
 
 
 # How long to ignore advertisements from the scale after a successful
@@ -648,35 +658,83 @@ class BleakScannerHybrid(BaseBleakScanner):
         self.seen_devices = {}
 
     async def start(self) -> None:
-        """Start scanning for devices."""
+        """Start scanning for devices.
+
+        Tolerates a partially-failing scanner instead of failing the whole
+        hybrid start. Previously a bare ``asyncio.gather`` here meant that if
+        one scanner's ``start()`` raised (e.g. native passive scanning
+        unavailable: "passive scanning on Linux requires BlueZ >= 5.56 with
+        --experimental enabled"), the exception propagated up while the
+        *other* scanner (e.g. the ESPHome proxy) had already finished
+        starting — but because ``self._scanning`` was never set to ``True``,
+        the ``except`` branch's call to ``self.stop()`` was a no-op (``stop``
+        early-returns when ``_scanning`` is falsy). The already-started
+        scanner was never stopped, leaking a live subscription. Each
+        subsequent registration-change restart (see
+        ``_async_registration_changed``) constructed a fresh
+        ``BleakScannerHybrid`` on top of the still-running leaked one, so
+        every incoming advertisement batch was processed once per leaked
+        instance — after enough restarts this alone saturated the event
+        loop, independent of restart frequency.
+
+        Now each scanner starts independently; a scanner whose ``start()``
+        raises is stopped explicitly and dropped, and scanning continues
+        with whichever scanners did start. Only if none of them start do we
+        raise.
+        """
         if self._scanning:
             return
 
         if not self._scanners:
             raise BleakError("No scanners available")
 
-        try:
-            # Start all scanners concurrently using asyncio.gather
-            await asyncio.gather(*[scanner.start() for scanner in self._scanners])
+        # Start all scanners concurrently, collecting failures instead of
+        # letting the first one abort everything.
+        results = await asyncio.gather(
+            *[scanner.start() for scanner in self._scanners],
+            return_exceptions=True,
+        )
 
-            # Check if at least one scanner started
-            if all(not getattr(s, "_scanning", False) for s in self._scanners):
-                raise BleakError("Failed to start any scanner")
+        started: list[BaseBleakScanner] = []
+        for scanner, result in zip(self._scanners, results):
+            if isinstance(result, BaseException):
+                _LOGGER.warning(
+                    "Failed to start %s (%s); continuing without it",
+                    type(scanner).__name__,
+                    result,
+                )
+                # The scanner's own start() failed, but it may still have
+                # partially initialized (e.g. subscribed to advertisements)
+                # before raising. Stop it explicitly rather than relying on
+                # BleakScannerHybrid.stop(), which no-ops until
+                # self._scanning is True.
+                try:
+                    await scanner.stop()
+                except Exception:  # noqa: BLE001
+                    pass
+                if scanner is self._native_scanner:
+                    self._native_scanner = None
+                if scanner is self._proxy_scanner:
+                    self._proxy_scanner = None
+            else:
+                started.append(scanner)
 
-            self._scanning = True
-            _LOGGER.debug(
-                "Hybrid scanner started with %s and %s",
-                "native scanner"
-                if self._native_scanner in self._scanners
-                else "no native scanner",
-                "proxy scanner"
-                if self._proxy_scanner in self._scanners
-                else "no proxy scanner",
-            )
-        except Exception as ex:
-            _LOGGER.exception("Error starting hybrid scanner: %s", ex)
-            await self.stop()
-            raise
+        self._scanners = started
+
+        if not started:
+            _LOGGER.error("Error starting hybrid scanner: no scanner could start")
+            raise BleakError("Failed to start any scanner")
+
+        self._scanning = True
+        _LOGGER.debug(
+            "Hybrid scanner started with %s and %s",
+            "native scanner"
+            if self._native_scanner in self._scanners
+            else "no native scanner",
+            "proxy scanner"
+            if self._proxy_scanner in self._scanners
+            else "no proxy scanner",
+        )
 
     async def stop(self) -> None:
         """Stop scanning for devices."""
@@ -804,6 +862,12 @@ class ScaleDataUpdateCoordinator:
         # change event firing during the initial start could double-start
         # the client.
         self._start_lock = asyncio.Lock()
+        # Backoff state for scanner-change restarts (see
+        # `_async_registration_changed`). Counts consecutive `_async_start`
+        # failures and holds the cancel handle of the (single, coalesced)
+        # scheduled retry.
+        self._restart_failures = 0
+        self._restart_retry_unsub: Callable[[], None] | None = None
         self._display_unit: WeightUnit = WeightUnit.KG
         self._config_entry_id: str | None = None
 
@@ -1237,13 +1301,68 @@ class ScaleDataUpdateCoordinator:
         self.hass.async_create_task(self._async_registration_changed())
 
     async def _async_registration_changed(self) -> None:
-        """Restart the scale client to pick up a new/changed scanner."""
+        """Restart the scale client to pick up a new/changed scanner.
+
+        Guarded by an exponential-backoff circuit breaker. Rebuilding the
+        whole BLE pipeline on every scanner-registration event with no
+        backoff means that once a restart starts failing persistently
+        (e.g. host BlueZ without passive-scanning support), each ESPHome
+        proxy reconnect triggers another full failing rebuild — and via the
+        leak in ``BleakScannerHybrid.start()`` fixed above, each one adds
+        more permanently-subscribed scanners on top, saturating the HA
+        event loop for hours. Now, while restarts are failing, further
+        registration events are coalesced into a single scheduled retry
+        whose delay grows exponentially (30s -> 30min cap). A successful
+        restart resets the backoff.
+        """
+        if self._restart_retry_unsub is not None:
+            # A backoff retry is already scheduled; coalesce this event.
+            _LOGGER.debug(
+                "Scale client restart already scheduled (backoff after %d "
+                "failure(s)); coalescing registration-change event",
+                self._restart_failures,
+            )
+            return
         _LOGGER.debug("BT scanner registration changed; restarting scale client")
         try:
             async with self._start_lock:
                 await self._async_start()
         except Exception:
-            _LOGGER.exception("Failed to restart scale client after scanner change")
+            self._restart_failures += 1
+            delay = min(
+                RESTART_BACKOFF_BASE_SECONDS * (2 ** (self._restart_failures - 1)),
+                RESTART_BACKOFF_MAX_SECONDS,
+            )
+            _LOGGER.exception(
+                "Failed to restart scale client after scanner change "
+                "(consecutive failure #%d); next retry in %ds",
+                self._restart_failures,
+                delay,
+            )
+            self._schedule_restart_retry(delay)
+        else:
+            if self._restart_failures:
+                _LOGGER.info(
+                    "Scale client restart succeeded after %d failed attempt(s); "
+                    "resetting backoff",
+                    self._restart_failures,
+                )
+            self._restart_failures = 0
+
+    def _schedule_restart_retry(self, delay: float) -> None:
+        """Schedule a single delayed restart retry.
+
+        Only one retry is ever pending; `_async_registration_changed` skips
+        new work while `_restart_retry_unsub` is set. The handle is cleared
+        both when the timer fires and in `async_stop`.
+        """
+
+        @callback
+        def _retry(_now) -> None:
+            self._restart_retry_unsub = None
+            self.hass.async_create_task(self._async_registration_changed())
+
+        self._restart_retry_unsub = async_call_later(self.hass, delay, _retry)
 
     def _library_logger(self) -> logging.Logger:
         """Logger handed to the renpho-escs20m client.
@@ -1285,6 +1404,11 @@ class ScaleDataUpdateCoordinator:
         if self._scanner_change_cb_unregister is not None:
             self._scanner_change_cb_unregister()
             self._scanner_change_cb_unregister = None
+        # Cancel any pending backoff retry so a stopped/unloaded coordinator
+        # can't restart itself later.
+        if self._restart_retry_unsub is not None:
+            self._restart_retry_unsub()
+            self._restart_retry_unsub = None
         if self._scale is not None:
             try:
                 await self._scale.async_stop()

--- a/custom_components/renpho_fitness_scale_ble/coordinator.py
+++ b/custom_components/renpho_fitness_scale_ble/coordinator.py
@@ -1340,29 +1340,23 @@ class ScaleDataUpdateCoordinator:
         added/removed) instead cancels any pending backoff retry and
         restarts immediately, since the event itself could be exactly
         what fixes the failure (e.g. an ESPHome proxy reconnecting).
+
         Registration events aren't rate-limited by HA itself, though, so a
-        flapping/bootlooping proxy could otherwise keep pre-empting the
-        backoff timer faster than the backoff is meant to allow (no leak,
-        but repeated real I/O load) - `REGISTRATION_PREEMPT_DEBOUNCE_SECONDS`
-        is a hard floor on that specific path. It only applies while a
-        backoff retry is pending (i.e. restarts are currently failing); it
-        does not throttle events while restarts are succeeding, since
-        pre-emption - and therefore this risk - can't occur on that path.
+        flapping/bootlooping proxy could otherwise drive restart attempts
+        faster than the backoff is meant to allow (no leak, but repeated
+        real I/O load). `REGISTRATION_PREEMPT_DEBOUNCE_SECONDS` is a hard
+        floor on *every* restart attempt made from here, regardless of
+        whether a backoff retry happens to be pending - covering both a
+        flapping proxy during an active backoff and one whose restarts
+        happen to keep succeeding (no backoff pending at all). The check
+        and the restart attempt both happen under `_start_lock`, so a
+        burst of events arriving while a restart is already in flight
+        queue up on the lock and then re-check the floor against the
+        latest attempt (including one that just finished) instead of all
+        slipping through on a stale check made before they were queued.
         A successful restart resets the backoff.
         """
-        if self._restart_retry_unsub is not None:
-            # A backoff retry is already scheduled, but this is a real
-            # registration-change event, not the retry timer firing (the
-            # timer's own callback clears `_restart_retry_unsub` before
-            # calling back in here). Normally we'd cancel the pending retry
-            # and try now - but only if enough time has passed since the
-            # last attempt; otherwise leave the scheduled backoff retry
-            # alone so repeated events can't drive back-to-back restarts.
-            # `_last_restart_attempt_monotonic` is always set by the time
-            # `_restart_retry_unsub` is non-None (both happen in the same
-            # call, `_last_restart_attempt_monotonic` first), so the None
-            # case below is unreachable today - kept as a defensive guard
-            # in case that invariant ever changes.
+        async with self._start_lock:
             since_last_attempt = (
                 None
                 if self._last_restart_attempt_monotonic is None
@@ -1374,54 +1368,60 @@ class ScaleDataUpdateCoordinator:
             ):
                 _LOGGER.debug(
                     "Registration-change event arrived %.1fs after the "
-                    "last restart attempt (< %ds debounce floor); leaving "
-                    "the scheduled backoff retry in place instead of "
-                    "pre-empting it",
+                    "last restart attempt (< %ds debounce floor); "
+                    "skipping this restart attempt",
                     since_last_attempt,
                     REGISTRATION_PREEMPT_DEBOUNCE_SECONDS,
                 )
                 return
-            _LOGGER.debug(
-                "Scale client restart already scheduled (backoff after %d "
-                "failure(s)); registration-change event pre-empting it for "
-                "an immediate retry",
-                self._restart_failures,
-            )
-            self._restart_retry_unsub()
-            self._restart_retry_unsub = None
-        _LOGGER.debug("BT scanner registration changed; restarting scale client")
-        try:
-            self._last_restart_attempt_monotonic = time.monotonic()
-            async with self._start_lock:
-                await self._async_start()
-        except Exception:
-            self._restart_failures += 1
-            delay = min(
-                RESTART_BACKOFF_BASE_SECONDS * (2 ** (self._restart_failures - 1)),
-                RESTART_BACKOFF_MAX_SECONDS,
-            )
-            _LOGGER.exception(
-                "Failed to restart scale client after scanner change "
-                "(consecutive failure #%d); next retry in %ds",
-                self._restart_failures,
-                delay,
-            )
-            self._schedule_restart_retry(delay)
-        else:
-            if self._restart_failures:
-                _LOGGER.info(
-                    "Scale client restart succeeded after %d failed attempt(s); "
-                    "resetting backoff",
+            if self._restart_retry_unsub is not None:
+                # A backoff retry is already scheduled, but this is a real
+                # registration-change event, not the retry timer firing
+                # (the timer's own callback clears `_restart_retry_unsub`
+                # before calling back in here) - cancel the pending retry
+                # and try now, since the event itself could be exactly
+                # what fixes the failure.
+                _LOGGER.debug(
+                    "Scale client restart already scheduled (backoff after "
+                    "%d failure(s)); registration-change event pre-empting "
+                    "it for an immediate retry",
                     self._restart_failures,
                 )
-            self._restart_failures = 0
+                self._restart_retry_unsub()
+                self._restart_retry_unsub = None
+            _LOGGER.debug("BT scanner registration changed; restarting scale client")
+            try:
+                self._last_restart_attempt_monotonic = time.monotonic()
+                await self._async_start()
+            except Exception:
+                self._restart_failures += 1
+                delay = min(
+                    RESTART_BACKOFF_BASE_SECONDS * (2 ** (self._restart_failures - 1)),
+                    RESTART_BACKOFF_MAX_SECONDS,
+                )
+                _LOGGER.exception(
+                    "Failed to restart scale client after scanner change "
+                    "(consecutive failure #%d); next retry in %ds",
+                    self._restart_failures,
+                    delay,
+                )
+                self._schedule_restart_retry(delay)
+            else:
+                if self._restart_failures:
+                    _LOGGER.info(
+                        "Scale client restart succeeded after %d failed "
+                        "attempt(s); resetting backoff",
+                        self._restart_failures,
+                    )
+                self._restart_failures = 0
 
     def _schedule_restart_retry(self, delay: float) -> None:
         """Schedule a single delayed restart retry.
 
-        Only one retry is ever pending; `_async_registration_changed` skips
-        new work while `_restart_retry_unsub` is set. The handle is cleared
-        both when the timer fires and in `async_stop`.
+        Only one retry is ever pending at a time - a new registration event
+        pre-empts it (subject to `REGISTRATION_PREEMPT_DEBOUNCE_SECONDS`)
+        rather than a second one being scheduled alongside it. The handle
+        is cleared both when the timer fires and in `async_stop`.
         """
 
         @callback


### PR DESCRIPTION
Fixes #14.

## What broke

On a host where native passive BLE scanning isn't available (BlueZ without `--experimental`), `BleakScannerHybrid.start()`'s bare `asyncio.gather()` meant the native scanner's exception propagated up and aborted the whole hybrid start — even though the ESPHome proxy scanner had already started successfully. Because `self._scanning` was never set to `True`, the `except` branch's `await self.stop()` was a no-op (`stop()` early-returns while `_scanning` is falsy), so the already-started proxy scanner was never stopped.

As confirmed in the issue thread, that's a leak, not just a retry loop: every failed restart left one live, subscribed `BleakScannerESPHome` running. `_async_registration_changed` rebuilds the whole pipeline on every scanner-registration event with no backoff, so on a host where the native scanner keeps failing, each ESPHome proxy reconnect both fails to restart *and* orphans another subscribed scanner on top of the previous ones. After ~1000 cycles over 30h, every incoming advertisement batch was being processed once per leaked instance, saturating the MainThread event loop for hours (HA API fully unresponsive, >20s timeouts).

## Fix

1. **`BleakScannerHybrid.start()`**: starts all scanners via `asyncio.gather(..., return_exceptions=True)`, explicitly stops (and drops) any scanner whose `start()` raised, and continues with whichever scanner(s) did start. Only raises if none started. This closes the leak directly — a failed scanner is stopped explicitly rather than relying on `BleakScannerHybrid.stop()`'s `_scanning`-gated cleanup.
2. **`_async_registration_changed`**: restarts are now gated behind an exponential backoff (30s → 30min cap). While a retry is pending, further registration events are coalesced instead of triggering another rebuild attempt. A successful restart resets the backoff. `async_stop` cancels any pending retry.

## Testing

No existing test suite in this repo to extend, so I verified against this exact patch with a standalone harness (fake scanners / mocked `_async_start` / mocked `async_call_later`, 21 checks): partial-scanner-failure tolerance and no-leak-on-repeated-restart (replaying the incident scenario — native always fails, proxy always succeeds, across 20 restart cycles), the backoff schedule (`[30, 60, 120, 240, 480, 960, 1800, 1800]`), event coalescing while a retry is pending, backoff reset on success, and retry cancellation in `async_stop`. `ruff check` and `ruff format --check` both pass.

I kept this PR scoped to the two fixes discussed in the issue. Happy to also take on the `BleakScannerHybrid.stop()` hardening (stop children regardless of `_scanning`) and the immediate-retry-on-registration-event idea mentioned in the thread as a follow-up, in this PR or a separate one — whichever you'd prefer.