### PR TITLE
Fix setup failure with a native adapter and no ESPHome proxies (org.bluez.Error.InProgress boot race)

### DIFF
--- a/custom_components/renpho_fitness_scale_ble/coordinator.py
+++ b/custom_components/renpho_fitness_scale_ble/coordinator.py
@@ -662,7 +662,8 @@ class BleakScannerHybrid(BaseBleakScanner):
                 self._scanners.append(self._proxy_scanner)
                 _LOGGER.debug("Proxy scanner initialized successfully")
             else:
-                _LOGGER.warning("No ESPHome clients provided for proxy scanner")
+                # Expected for the native-only passive configuration
+                _LOGGER.debug("No ESPHome clients provided for proxy scanner")
         except Exception as ex:
             _LOGGER.warning("Failed to initialize proxy scanner: %s", ex)
 
@@ -982,23 +983,32 @@ class ScaleDataUpdateCoordinator:
             # Get Bluetooth sources
             sources = manager._sources
             native = False
+            # Whether BlueZ exposes org.bluez.AdvertisementMonitorManager1
+            # for the adapter (bluetooth-adapters reports this as
+            # `passive_scan`) - i.e. whether bleak's passive scanning can
+            # work. Absent on Linux when BlueZ experimental features are
+            # disabled.
+            native_passive = False
 
             # Check for native adapters with better error handling
             try:
                 for adapter in manager._bluetooth_adapters.adapters.values():
                     if sources.get(adapter["address"]) is not None:
                         native = True
+                        native_passive = bool(adapter.get("passive_scan"))
                         _LOGGER.debug("Found native Bluetooth adapter: %s", adapter)
                         break
                 if not native:
-                    for adapter in manager._bluetooth_adapters.adapters.keys():
-                        if sources.get(adapter) is not None:
+                    for name, details in manager._bluetooth_adapters.adapters.items():
+                        if sources.get(name) is not None:
                             native = True
-                            _LOGGER.debug("Found native Bluetooth adapter: %s", adapter)
+                            native_passive = bool(details.get("passive_scan"))
+                            _LOGGER.debug("Found native Bluetooth adapter: %s", details)
                             break
             except (AttributeError, KeyError) as err:
                 _LOGGER.warning("Error checking native Bluetooth adapters: %s", err)
                 native = False
+                native_passive = False
 
             # Get ESPHome proxies with error handling
             esphome_clients: list[APIClient] = []
@@ -1050,7 +1060,7 @@ class ScaleDataUpdateCoordinator:
                         "Unexpected error creating Bluetooth scanner: %s", ex
                     )
                     scanner = None
-            elif native:
+            elif native and native_passive:
                 # Native adapter without ESPHome proxies. Returning None here
                 # would make the scale library create its own ACTIVE
                 # BleakScanner, whose StartDiscovery races Home Assistant's
@@ -1074,6 +1084,24 @@ class ScaleDataUpdateCoordinator:
                         "Unexpected error creating Bluetooth scanner: %s", ex
                     )
                     scanner = None
+            elif native:
+                # Native adapter, but BlueZ does not expose the
+                # AdvertisementMonitor API needed for passive scanning
+                # (on Linux this usually means BlueZ experimental features
+                # are disabled). Keep the previous behavior - the scale
+                # library will run its own active scanner - instead of
+                # failing hard, but explain how to get the race-free path.
+                _LOGGER.warning(
+                    "Passive scanning is not available on this adapter "
+                    "(BlueZ AdvertisementMonitor API not exposed), so the "
+                    "scale library will use its own active scanner. This "
+                    "can fail with org.bluez.Error.InProgress while Home "
+                    "Assistant's shared scanner is starting up (issue #13). "
+                    "For reliable startup, enable BlueZ experimental "
+                    "features (Experimental = true in "
+                    "/etc/bluetooth/main.conf; requires BlueZ >= 5.56 and "
+                    "kernel >= 5.10) and restart the bluetooth service"
+                )
             else:
                 # No ESPHome proxies AND no native adapter = no Bluetooth available
                 raise BluetoothNotAvailableError(

--- a/custom_components/renpho_fitness_scale_ble/coordinator.py
+++ b/custom_components/renpho_fitness_scale_ble/coordinator.py
@@ -1050,7 +1050,31 @@ class ScaleDataUpdateCoordinator:
                         "Unexpected error creating Bluetooth scanner: %s", ex
                     )
                     scanner = None
-            elif not native:
+            elif native:
+                # Native adapter without ESPHome proxies. Returning None here
+                # would make the scale library create its own ACTIVE
+                # BleakScanner, whose StartDiscovery races Home Assistant's
+                # shared scanner during startup (org.bluez.Error.InProgress),
+                # so entry setup keeps failing after a host reboot (issue #13).
+                # A native-only PASSIVE scanner (BlueZ AdvertisementMonitor)
+                # coexists with the shared scanner.
+                try:
+                    scanner = BleakScannerHybrid(
+                        None,
+                        None,
+                        BluetoothScanningMode.PASSIVE,
+                        [],
+                    )
+                    _LOGGER.debug("Created native-only passive scanner")
+                except BleakError as err:
+                    _LOGGER.warning("Failed to initialize Bluetooth scanner: %s", err)
+                    scanner = None
+                except Exception as ex:
+                    _LOGGER.exception(
+                        "Unexpected error creating Bluetooth scanner: %s", ex
+                    )
+                    scanner = None
+            else:
                 # No ESPHome proxies AND no native adapter = no Bluetooth available
                 raise BluetoothNotAvailableError(
                     "No Bluetooth adapter or ESPHome proxy available"


### PR DESCRIPTION
## Problem

On systems with a **native Bluetooth adapter and no ESPHome proxies**, the integration fails to set up after a Home Assistant host reboot and never recovers — every retry logs:

```
bleak.exc.BleakError: [org.bluez.Error.InProgress] Operation already in progress
```

This is the bug reported in #13. Restarting core, reloading the entry, or power-cycling the adapter doesn't clear it; only installing/starting the integration *after* HA has fully settled works, which is why it can appear to work for days and then break on the first reboot.

## Root cause (two independent bugs)

**1. `_get_bluetooth_scanner()` returns `None` for the native-only case.**
A scanner is only assigned inside the `len(esphome_clients) > 0` branch. With `native=True` and no proxies, the function falls through and returns `None`, so the `renpho-escs20m` library falls back to creating its own **active** `BleakScanner`. Its `StartDiscovery` races Home Assistant's shared (habluetooth) scanner during startup, producing the endless `org.bluez.Error.InProgress` loop. Passive scanning doesn't have this problem: it uses the BlueZ AdvertisementMonitor API, which coexists with the shared scanner by design — exactly what `BleakScannerHybrid` already does for the hybrid case.

**2. The liveness check in `BleakScannerHybrid.start()` probes a gone attribute.**
The BlueZ backend in the bleak version shipped with current Home Assistant no longer exposes `_scanning`, so even a successfully started scanner failed `all(not getattr(s, "_scanning", False) ...)` and raised `Failed to start any scanner`. A running BlueZ scan is indicated by the `_stop` callback the backend stores, so the check now probes both. Without this second fix, the first fix can't work on current HA.

## Fix

- Native adapter + no proxies now gets `BleakScannerHybrid(None, None, PASSIVE, [])` — the existing hybrid class with an empty proxy list, i.e. native-only passive scanning. Error handling mirrors the existing proxy branch (fall back to `scanner = None` on failure, preserving current degraded behavior).
- The liveness check accepts either `_scanning` (older bleak) or a stored `_stop` callback (current bleak).

## Testing

Developed and verified as a backport on 0.2.2 (both code sites are unchanged between 0.2.2 and main), then ported here onto main:

- HAOS VM (HA core 2026.7.2), native USB adapter (TP-Link UB500, BlueZ), no ESPHome proxies, two ES-CS20M scales.
- **Before:** every host reboot → ~100 consecutive setup retries, all failing with `org.bluez.Error.InProgress`; integration never came up.
- **After:** clean setup on boot (`Created native-only passive scanner` in debug logs, zero InProgress errors), and multiple end-to-end weigh-ins from both scales landed, including body composition over GATT.

## Notes

- An even smaller alternative: `renpho-escs20m` accepts `scanning_mode=PASSIVE`, so passing that through when no backend is injected would also avoid the race — happy to rework the PR that way if you prefer.
- Longer term, the canonical HA approach would be consuming the shared Bluetooth stack directly (`bluetooth.async_register_callback` for advertisements + `async_ble_device_from_address`/`bleak-retry-connector` for connections), but that's a larger restructuring of how the library gets its data — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yvu1oNFhpqjqTSGtTvmyz

## Update: graceful fallback when passive scanning is unavailable

Testing by @brenard on #13 (thanks!) showed that on HA Container/Core installs, bleak's passive scanning requires BlueZ >= 5.56 with **experimental features enabled** (`Experimental = true` in `/etc/bluetooth/main.conf`) and kernel >= 5.10 — HA OS enables this out of the box, plain distro installs often don't, and the passive scanner then fails hard at start.

The second commit gates the passive path on the adapter's `passive_scan` capability, which `bluetooth-adapters` derives from whether BlueZ exposes `org.bluez.AdvertisementMonitorManager1` — i.e. it reflects the exact runtime condition bleak needs, and flips to `True` once experimental is enabled. Behavior matrix:

| System | Before this PR | With this PR |
|---|---|---|
| Passive supported (HA OS, or experimental enabled) | boot race, setup fails (#13) | native passive scanner, race-free |
| Passive not supported | boot race, setup fails (#13) | unchanged behavior + a warning explaining how to enable the passive path |

So nobody is forced to enable experimental features: systems that can't do passive keep exactly the current behavior, with an actionable log message instead of a mystery.
