### PR TITLE
Keep weight_history out of the recorder to unblock statistics

### DIFF
--- a/custom_components/renpho_fitness_scale_ble/sensor.py
+++ b/custom_components/renpho_fitness_scale_ble/sensor.py
@@ -177,9 +177,17 @@ class ScaleUserWeightSensor(ScaleUserSensor):
     own displayed value.
     """
 
+    # Never record the history attribute: past the recorder's 16 KB attribute
+    # limit (MAX_STATE_ATTRS_BYTES, ~68 entries) the recorder stores {} for
+    # ALL of the state's attributes, and statistics compilation then sees a
+    # state without unit_of_measurement and suppresses long-term statistics.
+    _unrecorded_attributes = frozenset({"weight_history"})
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        history = self._coordinator._router.get_user_history(self._user_id)
+        # Cap the live attribute to the newest 20 entries; with
+        # keep_history_forever the full history is unbounded.
+        history = self._coordinator._router.get_user_history(self._user_id)[-20:]
         return {
             "weight_history": [
                 self._coordinator.format_measurement_for_attribute(


### PR DESCRIPTION
The weight sensor serialized the full per-user history into its weight_history attribute on every state write. Past the recorder's 16 KB attribute limit (~68 entries, inevitable with default retention and guaranteed with keep-history-forever) the recorder stores {} for ALL of the state's attributes, so statistics compilation sees a state without unit_of_measurement and suppresses long-term statistics ("unit (None) cannot be converted ... (kg)").

Mark weight_history as unrecorded so the recorded state always keeps its unit at any history size, and cap the live attribute to the newest 20 entries.